### PR TITLE
Add "import Foundation" to example so that it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ and you wanted to import [mxcl/PromiseKit](https://github.com/mxcl/PromiseKit):
 ```swift
 #!/usr/bin/swift sh
 
+import Foundation
 import PromiseKit  // @mxcl ~> 6.5
 
 firstly {


### PR DESCRIPTION
was getting these errors:
```
Compile Swift Module 'test' (1 sources)
/Users/dan/Library/Developer/swift-sh.cache/test/main.swift:10:5: error: use of unresolved identifier 'exit'
    exit(0)
    ^~~~
/Users/dan/Library/Developer/swift-sh.cache/test/main.swift:13:1: error: use of unresolved identifier 'RunLoop'
RunLoop.main.run()
^~~~~~~
error: terminated(1): /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-build-tool -f /Users/dan/Library/Developer/swift-sh.cache/test/.build/debug.yaml test.exe output:
    Compile Swift Module 'test' (1 sources)
    /Users/dan/Library/Developer/swift-sh.cache/test/main.swift:10:5: error: use of unresolved identifier 'exit'
        exit(0)
        ^~~~
    /Users/dan/Library/Developer/swift-sh.cache/test/main.swift:13:1: error: use of unresolved identifier 'RunLoop'
    RunLoop.main.run()
    ^~~~~~~


Fatal error: Error raised at top level: (extension in Shwifty):__C.NSTask.ExecutionError(stdout: (extension in Shwifty):__C.NSTask.Output, stderr: (extension in Shwifty):__C.NSTask.Output, status: 1, arg0: "/usr/bin/swift", args: ["run"]): file /BuildRoot/Library/Caches/com.apple.xbs/Sources/swiftlang_Fall2018/swiftlang_Fall2018-1000.11.42/src/swift/stdlib/public/core/ErrorType.swift, line 191
fish: './test.swift' terminated by signal SIGILL (Illegal instruction)
```