### PR TITLE
Fix support for exactly-specified dependency versions

### DIFF
--- a/Sources/Library/ImportSpecification.swift
+++ b/Sources/Library/ImportSpecification.swift
@@ -21,7 +21,7 @@ public extension ImportSpecification {
                 .upToNextMajor(from: "\(v)")
                 """
             case .exact(let v):
-                return ".exactItem(Version(\(v.major),\(v.minor),\(v.patch)))"
+                return ".exact(\"\(v.major).\(v.minor).\(v.patch)\")"
             case .ref(let ref):
                 return """
                 .revision("\(ref)")


### PR DESCRIPTION
This commit updates the generated Package.swift to
specify the exact version of a dependency via an expression
of the following form: `.exact("1.5.8")`. This works for
Swift Package Manager 4.2