### PR TITLE
Fix Dependencies with Hyphens in Name or URL Not Importing

### DIFF
--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -4,7 +4,7 @@ import Version
 
 /// - Parameter line: Contract: Single line string trimmed of whitespace.
 func parse(_ line: String) -> ImportSpecification? {
-    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*(@?[\\w\\/:\\.]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
+    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*(@?[\\w\\/:\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
     guard let match = rx.firstMatch(in: line) else { return nil }
 

--- a/Tests/All/UnitTests.swift
+++ b/Tests/All/UnitTests.swift
@@ -45,12 +45,26 @@ class UnitTests: XCTestCase {
         XCTAssertEqual(b?.constraint, .upToNextMajor(from: .one))
         XCTAssertEqual(b?.importName, "Foo")
     }
+    
+    func testCanOverrideImportNameUsingNameWithHyphen() {
+        let b = parse("import Bar  // mxcl/swift-bar ~> 1.0")
+        XCTAssertEqual(b?.dependencyName, "mxcl/swift-bar")
+        XCTAssertEqual(b?.constraint, .upToNextMajor(from: .one))
+        XCTAssertEqual(b?.importName, "Bar")
+    }
 
     func testCanProvideFullURL() {
         let b = parse("import Foo  // https://example.com/mxcl/Bar.git ~> 1.0")
         XCTAssertEqual(b?.dependencyName, "https://example.com/mxcl/Bar.git")
         XCTAssertEqual(b?.constraint, .upToNextMajor(from: .one))
         XCTAssertEqual(b?.importName, "Foo")
+    }
+
+    func testCanProvideFullURLWithHyphen() {
+        let b = parse("import Bar  // https://example.com/mxcl/swift-bar.git ~> 1.0")
+        XCTAssertEqual(b?.dependencyName, "https://example.com/mxcl/swift-bar.git")
+        XCTAssertEqual(b?.constraint, .upToNextMajor(from: .one))
+        XCTAssertEqual(b?.importName, "Bar")
     }
 
     func testCanDoSpecifiedImports() {

--- a/Tests/All/XCTestManifests.swift
+++ b/Tests/All/XCTestManifests.swift
@@ -59,7 +59,9 @@ extension UnitTests {
     static let __allTests__UnitTests = [
         ("testCanDoSpecifiedImports", testCanDoSpecifiedImports),
         ("testCanOverrideImportName", testCanOverrideImportName),
+        ("testCanOverrideImportNameUsingNameWithHyphen", testCanOverrideImportNameUsingNameWithHyphen),
         ("testCanProvideFullURL", testCanProvideFullURL),
+        ("testCanProvideFullURLWithHyphen", testCanProvideFullURLWithHyphen),
         ("testCanUseTestable", testCanUseTestable),
         ("testExact", testExact),
         ("testLatestVersion", testLatestVersion),


### PR DESCRIPTION
example: https://github.com/ilyapuchka/swift-prelude does not import

```
error: failed to clone; Cloning into bare repository '/Users/dan/Library/Developer/swift-sh.cache/test/.build/repositories/swift-78d18ed4'...
remote: Repository not found.
fatal: repository 'https://github.com/pointfreeco/swift/' not found
error: 1 <(/usr/bin/swift build -Xswiftc -suppress-warnings)
```