### PR TITLE
Add support for local dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ import CommonTaDa    // git@github.com:mxcl/tada.git ~> 1
 import TaDa    // ssh://git@github.com:mxcl/tada.git ~> 1
 // ^^ this style of ssh URLs are fine too
 
+import Foo // /Users/max/Desktop/foo
+// ^^ support for local dependencies (assuming the directory path is valid)
+
 ```
 
 `swift-sh` reads the comments after your imports and fetches the requested

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ import TaDa    // ssh://git@github.com:mxcl/tada.git ~> 1
 import Foo // /Users/max/Desktop/foo
 // ^^ support for local dependencies (assuming the directory path is valid)
 
+import Foo // ~/Desktop/foo
+// ^^ using "~/" for local dependencies is fine too
+
 ```
 
 `swift-sh` reads the comments after your imports and fetches the requested

--- a/Sources/Script/ImportSpecification.swift
+++ b/Sources/Script/ImportSpecification.swift
@@ -10,6 +10,7 @@ public struct ImportSpecification: Codable, Equatable {
     enum DependencyName: Equatable {
         case url(URL)
         case scp(String)
+        case local(Path)
         case github(user: String, repo: String)
     }
 
@@ -30,9 +31,16 @@ extension ImportSpecification {
     }
 
     public var packageLine: String {
-        return """
-        .package(url: "\(dependencyName.urlString)", \(requirement))
-        """
+        switch dependencyName {
+        case .local:
+            return """
+            .package(path: "\(dependencyName.urlString)"
+            """
+        default:
+            return """
+            .package(url: "\(dependencyName.urlString)", \(requirement))
+            """
+        }
     }
 
     private var requirement: String {

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -8,7 +8,7 @@ enum E: Error {
 
 /// - Parameter line: Contract: Single line string trimmed of whitespace.
 func parse(_ line: String) throws -> ImportSpecification? {
-    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*(@?[\\w\\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
+    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w\\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
 
     // doesn’t look like an import line, we have to silently ignore it, even though it could

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -53,6 +53,14 @@ class ImportSpecificationUnitTests: XCTestCase {
         XCTAssertEqual(b?.importName, "Bar")
     }
 
+    func testCanProvideLocalPath() throws {
+        let homePath = Path.home
+        let b = try parse("import Bar  // \(homePath.string)")
+        XCTAssertEqual(b?.dependencyName, .local(homePath))
+        XCTAssertEqual(b?.importName, "Bar")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\"")
+    }
+
     func testCanProvideFullURL() throws {
         let b = try parse("import Foo  // https://example.com/mxcl/Bar.git ~> 1.0")
         XCTAssertEqual(b?.dependencyName, .url(URL(string: "https://example.com/mxcl/Bar.git")!))

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -61,6 +61,14 @@ class ImportSpecificationUnitTests: XCTestCase {
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\"")
     }
 
+    func testCanProvideLocalPathWithTilde() throws {
+        let homePath = Path.home
+        let b = try parse("import Bar  // ~/")
+        XCTAssertEqual(b?.dependencyName, .local(homePath))
+        XCTAssertEqual(b?.importName, "Bar")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\"")
+    }
+
     func testCanProvideFullURL() throws {
         let b = try parse("import Foo  // https://example.com/mxcl/Bar.git ~> 1.0")
         XCTAssertEqual(b?.dependencyName, .url(URL(string: "https://example.com/mxcl/Bar.git")!))

--- a/Tests/All/XCTestManifests.swift
+++ b/Tests/All/XCTestManifests.swift
@@ -27,6 +27,7 @@ extension ImportSpecificationUnitTests {
         ("testCanProvideFullURL", testCanProvideFullURL),
         ("testCanProvideFullURLWithHyphen", testCanProvideFullURLWithHyphen),
         ("testCanProvideLocalPath", testCanProvideLocalPath),
+        ("testCanProvideLocalPathWithTilde", testCanProvideLocalPathWithTilde),
         ("testCanUseTestable", testCanUseTestable),
         ("testExact", testExact),
         ("testLatestVersion", testLatestVersion),

--- a/Tests/All/XCTestManifests.swift
+++ b/Tests/All/XCTestManifests.swift
@@ -26,6 +26,7 @@ extension ImportSpecificationUnitTests {
         ("testCanProvideFullSSHURLWithHyphen", testCanProvideFullSSHURLWithHyphen),
         ("testCanProvideFullURL", testCanProvideFullURL),
         ("testCanProvideFullURLWithHyphen", testCanProvideFullURLWithHyphen),
+        ("testCanProvideLocalPath", testCanProvideLocalPath),
         ("testCanUseTestable", testCanUseTestable),
         ("testExact", testExact),
         ("testLatestVersion", testLatestVersion),


### PR DESCRIPTION
**Resolves issue: https://github.com/mxcl/swift-sh/issues/76**

Supports local dependencies when full local path is written or using `~/` prefix.

If the dependency is not scp or a github dependency with the `@` symbol prefix, we check if the string path is valid in the user's file system using the Path dependency before setting the dependency as _local_. This way, we still allow github dependencies without the `@` prefix.

If determined to be a local dependency, a new `DependencyName` enum case holds the dependency as a Path, which facilitates providing the dependency string when generating the `Package.swift` and when decoding. Moreover, this enum case is used to provide the correct `packageline`.

The related test makes use of `Path.home` to have a directory that is valid for testing wherever the test is run.

Also, updates README.