### PR TITLE
Fix missing closing parenthesis for local deps

### DIFF
--- a/Sources/Script/ImportSpecification.swift
+++ b/Sources/Script/ImportSpecification.swift
@@ -34,7 +34,7 @@ extension ImportSpecification {
         switch dependencyName {
         case .local:
             return """
-            .package(path: "\(dependencyName.urlString)"
+            .package(path: "\(dependencyName.urlString)")
             """
         default:
             return """

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -58,7 +58,7 @@ class ImportSpecificationUnitTests: XCTestCase {
         let b = try parse("import Bar  // \(homePath.string)")
         XCTAssertEqual(b?.dependencyName, .local(homePath))
         XCTAssertEqual(b?.importName, "Bar")
-        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\"")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\")")
     }
 
     func testCanProvideLocalPathWithTilde() throws {
@@ -66,7 +66,7 @@ class ImportSpecificationUnitTests: XCTestCase {
         let b = try parse("import Bar  // ~/")
         XCTAssertEqual(b?.dependencyName, .local(homePath))
         XCTAssertEqual(b?.importName, "Bar")
-        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\"")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\")")
     }
 
     func testCanProvideFullURL() throws {

--- a/Tests/All/IntegrationTests.swift
+++ b/Tests/All/IntegrationTests.swift
@@ -78,6 +78,23 @@ class RunIntegrationTests: XCTestCase {
             """)
     }
 
+    func testUseLocalDependency() throws {
+        let tmpdir = try Path.cwd.join("local_dep").mkdir()
+        defer {_ = try? FileManager.default.removeItem(at: tmpdir.url)}
+
+        let task = Process(arg0: "/bin/bash")
+        task.currentDirectoryPath = tmpdir.string
+        task.arguments = ["-c", "swift package init"]
+        let stdout = Pipe()
+        task.standardOutput = stdout
+        try task.go()
+        task.waitUntilExit()
+
+        XCTAssertRuns(exec: """
+            import local_dep  // \(tmpdir.string)
+            """)
+    }
+
     func testStandardInputCanBeUsedInScript() throws {
         let stdin = Pipe()
         let stdout = Pipe()

--- a/Tests/All/XCTestManifests.swift
+++ b/Tests/All/XCTestManifests.swift
@@ -86,6 +86,7 @@ extension RunIntegrationTests {
         ("testTestableFullySpecifiedURL", testTestableFullySpecifiedURL),
         ("testTestableImport", testTestableImport),
         ("testTestableLatest", testTestableLatest),
+        ("testUseLocalDependency", testUseLocalDependency),
     ]
 }
 


### PR DESCRIPTION
I just noticed that there is a syntax error for local dependencies, doh! — missing the closing `)`.

Tests updated.