### PR TITLE
Support for any $EDITOR with swift sh editor <script>

### DIFF
--- a/Sources/Command/CommandLine.usage.swift
+++ b/Sources/Command/CommandLine.usage.swift
@@ -9,6 +9,7 @@ public extension CommandLine {
             swift sh <script> [arguments]
             swift sh eject <script> [-f|--force]
             swift sh --clean-cache [-C]
+            swift sh editor <script>
             """
       #if os(macOS)
         rv += "\nswift sh edit <script>"
@@ -97,6 +98,7 @@ public enum Mode {
     case run(RunType, args: ArraySlice<String>)
     case eject(Path, force: Bool)
     case edit(Path)
+    case editor(Path)
     case clean
     case help
 
@@ -127,6 +129,14 @@ public enum Mode {
                 throw CommandLine.Error.invalidUsage
             }
             self = .edit(Path(arg1) ?? Path.cwd/arg1)
+        case "editor"?:
+            guard let arg1 = parser.pop() else {
+                throw CommandLine.Error.invalidUsage
+            }
+            guard parser.isEmpty else {
+                throw CommandLine.Error.invalidUsage
+            }
+            self = .editor(Path(arg1) ?? Path.cwd/arg1)
         case "-"?, "--"?:
             self = .run(.stdin, args: parser.remainder)
         case "--help"?, "-h"?:

--- a/Sources/Command/editor().swift
+++ b/Sources/Command/editor().swift
@@ -1,0 +1,19 @@
+import Foundation
+import Utility
+import Script
+import Path
+
+public func editor(path: Path) throws -> Never {
+    let deps = try StreamReader(path: path).compactMap(ImportSpecification.init)
+    let script = Script(for: .path(path), dependencies: deps)
+    try script.write()
+
+    guard let editor = ProcessInfo.processInfo.environment["EDITOR"] else {
+        fatalError("EDITOR undefined")
+    }
+    guard let path = Path(editor) ?? Path.which(editor) else {
+        fatalError("EDITOR not in PATH")
+    }
+    chdir(script.buildDirectory.string)
+    try exec(arg0: path.string, args: [script.mainSwift.string])
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -15,6 +15,8 @@ do {
         try Command.eject(path, force: force)
     case .edit(let path):
         try Command.edit(path: path)
+    case .editor(let path):
+        try Command.editor(path: path)
     case .clean:
         try Path.build.delete()
     case .help:


### PR DESCRIPTION
Use `swift sh editor <script>` to open `script.mainSwift` in `$EDITOR` and set the path for the `$EDITOR` to `script.buildDirectory`.

This allows editors such as Vim or VSCode to enable their IDE like functionality.