### PR TITLE
address issue #93 - caching problem if script by same name is in two locations in the file system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /swift-sh.xcodeproj
 /sync
 /.swiftpm
+.build

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -8,7 +8,6 @@ public class Script {
     let input: Input
     let deps: [ImportSpecification]
     let args: [String]
-    let cwd: Path
 
     public var name: String {
         switch input {
@@ -24,7 +23,7 @@ public class Script {
             case .path(let path):
                 return Path.build/path.pathHash()
             case .string:
-                return Path.build/cwd.pathHash()
+                return Path.build/name
         }
     }
 
@@ -41,7 +40,6 @@ public class Script {
         input = `for`
         deps = dependencies
         args = arguments
-        cwd = Path.cwd
     }
 
     var depsCachePath: Path {

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -20,12 +20,12 @@ public class Script {
     }
 
     public var buildDirectory: Path {
-		switch input {
-			case .path(let path):
-				return Path.build/path.pathHash()
-			case .string:
-				return Path.build/cwd.pathHash()
-		}
+        switch input {
+            case .path(let path):
+                return Path.build/path.pathHash()
+            case .string:
+                return Path.build/cwd.pathHash()
+        }
     }
 
     public var mainSwift: Path {
@@ -182,14 +182,14 @@ extension Path {
 }
 
 extension Path {
-	func pathHash() -> String {
-		var s = self.basename(dropExtension: true)	// default result
-		guard let data = self.string.data(using: .utf8) else { return s }
-		if let b64s = String(data: data.base64EncodedData(), encoding: .utf8)?.suffix(128) {
-		   s = String(b64s)
-		}
-		return s
-	}
+    func pathHash() -> String {
+        var s = self.basename(dropExtension: true)  // default result
+        guard let data = self.string.data(using: .utf8) else { return s }
+        if let b64s = String(data: data.base64EncodedData(), encoding: .utf8)?.suffix(128) {
+           s = String(b64s)
+        }
+        return s
+    }
 }
 
 extension String {

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -1,5 +1,3 @@
-
-import CryptoKit
 import StreamReader
 import Foundation
 import Utility
@@ -187,22 +185,9 @@ extension Path {
 	func pathHash() -> String {
 		var s = self.basename(dropExtension: true)	// default result
 		guard let data = self.string.data(using: .utf8) else { return s }
-
-		// CryptoKit isn't available prior to 10.15
-		// but the compiler is not weak linking it like it should
-		// so have to comment this out for now and just use b64 :-(
-		// Filed: FB7471728 against this.
-		// See: https://forums.swift.org/t/weak-linking-of-frameworks-with-greater-deployment-targets/26017
-		/* if #available(iOS 13, macOS 10.15, *) {
-			let digest = Insecure.SHA1.hash(data: data)
-			for byte in digest {
-				s += String(format:"%02x", UInt8(byte))
-			}
-		} else { */
-			if let b64s = String(data: data.base64EncodedData(), encoding: .utf8)?.suffix(128) {
-			   s = String(b64s)
-			}
-		// }
+		if let b64s = String(data: data.base64EncodedData(), encoding: .utf8)?.suffix(128) {
+		   s = String(b64s)
+		}
 		return s
 	}
 }

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -8,7 +8,7 @@ public class Script {
     let input: Input
     let deps: [ImportSpecification]
     let args: [String]
-	let cwd: Path
+    let cwd: Path
 
     public var name: String {
         switch input {
@@ -41,7 +41,7 @@ public class Script {
         input = `for`
         deps = dependencies
         args = arguments
-		cwd = Path.cwd
+        cwd = Path.cwd
     }
 
     var depsCachePath: Path {


### PR DESCRIPTION
Addresses issue #94.

Planned to use a sha1 hash of the pathname as the cache folder name, but CryptoKit isn't available until 10.15 and might not be available at all on linux.
So just using the last 128 characters of the base64 encoded path passed to swift-sh instead.

Was going to just use the current working directory for string case, but in those cases swift-sh is doing a full rebuild every time because it can't check for changes; so no need to address that case anyway.