### PR TITLE
Fix #93 - caching collision for script by same name is in two locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /swift-sh.xcodeproj
 /sync
 /.swiftpm
+.build

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -19,7 +19,12 @@ public class Script {
     }
 
     public var buildDirectory: Path {
-        return Path.build/name
+        switch input {
+            case .path(let path):
+                return Path.build/path.pathHash()
+            case .string:
+                return Path.build/name
+        }
     }
 
     public var mainSwift: Path {
@@ -171,6 +176,17 @@ extension Path {
             let str = (try? task.runSync())?.stdout.string?.chuzzled() ?? "/usr/bin/swift"
             return Path.root/str
         }
+    }
+}
+
+extension Path {
+    func pathHash() -> String {
+        var s = self.basename(dropExtension: true)  // default result
+        guard let data = self.string.data(using: .utf8) else { return s }
+        if let b64s = String(data: data.base64EncodedData(), encoding: .utf8)?.suffix(128) {
+           s = String(b64s)
+        }
+        return s
     }
 }
 


### PR DESCRIPTION
Addresses issue #93 

Planned to use a sha1 hash of the pathname as the cache folder name, but CryptoKit isn't available until 10.15 and might not be available at all on linux.
So just using the last 128 characters of the base64 encoded path passed to swift-sh instead.  Does mean `pathHash` is somewhat of a misnomer I suppose.

Thought about use current working directory for non-file/string case, but in those cases swift-sh is doing a full rebuild every time because it can't check for changes; so no need to address that case anyway.