### PR TITLE
Make relative paths relative to script location and not current working directory

### DIFF
--- a/Sources/Command/edit().swift
+++ b/Sources/Command/edit().swift
@@ -6,7 +6,8 @@ import Path
 
 public func edit(path: Path) throws -> Never {
 #if os(macOS)
-    let deps = try StreamReader(path: path).compactMap(ImportSpecification.init)
+    let input:Script.Input = .path(path)
+    let deps = try StreamReader(path: path).compactMap { try ImportSpecification(line: $0, from: input) }
     let script = Script(for: .path(path), dependencies: deps)
     try script.write()
     try exec(arg0: "/usr/bin/swift", args: ["sh-edit", path.string, script.buildDirectory.string])

--- a/Sources/Command/editor().swift
+++ b/Sources/Command/editor().swift
@@ -5,7 +5,8 @@ import Script
 import Path
 
 public func editor(path: Path) throws -> Never {
-    let deps = try StreamReader(path: path).compactMap(ImportSpecification.init)
+    let input:Script.Input = .path(path)
+    let deps = try StreamReader(path: path).compactMap { try ImportSpecification(line: $0, from: input) }
     let script = Script(for: .path(path), dependencies: deps)
     try script.write()
 

--- a/Sources/Command/eject().swift
+++ b/Sources/Command/eject().swift
@@ -11,7 +11,8 @@ public func eject(_ script: Path, force: Bool) throws {
 
     let reader = try StreamReader(path: script).makeIterator()
     guard force || reader.next().isShebang else { throw EjectError.notScript }
-    let deps = try reader.compactMap(ImportSpecification.init)
+    let input:Script.Input = .path(script)
+    let deps = try reader.compactMap { try ImportSpecification(line: $0, from: input) }
     let name = script.basename(dropExtension: true).capitalized
     let containingDirectory = script.parent
 

--- a/Sources/Command/run().Input.swift
+++ b/Sources/Command/run().Input.swift
@@ -8,7 +8,7 @@ import Darwin
 import Glibc
 #endif
 
-public enum Input {
+enum Input {
     case stdin
     case file(Path)
     case namedPipe(FileHandle)

--- a/Sources/Command/run().Input.swift
+++ b/Sources/Command/run().Input.swift
@@ -8,7 +8,7 @@ import Darwin
 import Glibc
 #endif
 
-enum Input {
+public enum Input {
     case stdin
     case file(Path)
     case namedPipe(FileHandle)

--- a/Sources/Command/run().swift
+++ b/Sources/Command/run().swift
@@ -37,8 +37,6 @@ private func run<T>(reader: StreamReader, input: Input, arguments: T) throws -> 
         }
     }
 
-
-
     for (index, line) in reader.enumerated() {
         if index == 0, line.hasPrefix("#!") {
             lines.append("// shebang removed")  // keep line numbers in sync

--- a/Sources/Command/run().swift
+++ b/Sources/Command/run().swift
@@ -28,12 +28,23 @@ private func run<T>(reader: StreamReader, input: Input, arguments: T) throws -> 
     var deps = [ImportSpecification]()
     var lines = [String]()
 
+    var transformedInput: Script.Input {
+        switch input {
+        case .stdin, .namedPipe:
+            return .string(name: input.name, content: lines.joined(separator: "\n"))
+        case .file(let path):
+            return .path(path)
+        }
+    }
+
+
+
     for (index, line) in reader.enumerated() {
         if index == 0, line.hasPrefix("#!") {
             lines.append("// shebang removed")  // keep line numbers in sync
             continue
         }
-        if let result = try ImportSpecification(line: line) {
+        if let result = try ImportSpecification(line: line, from: transformedInput) {
             deps.append(result)
         }
         switch input {
@@ -41,15 +52,6 @@ private func run<T>(reader: StreamReader, input: Input, arguments: T) throws -> 
             lines.append(line)
         case .file:
             break
-        }
-    }
-
-    var transformedInput: Script.Input {
-        switch input {
-        case .stdin, .namedPipe:
-            return .string(name: input.name, content: lines.joined(separator: "\n"))
-        case .file(let path):
-            return .path(path)
         }
     }
 

--- a/Sources/Script/DependencyName.swift
+++ b/Sources/Script/DependencyName.swift
@@ -44,7 +44,6 @@ extension ImportSpecification.DependencyName: Codable {
                 let localRelativePathPrefix: Path
                 switch input {
                 case .path(let path):
-                    print("path found")
                     localRelativePathPrefix = path.parent
                 case .string:
                     localRelativePathPrefix = Path.cwd

--- a/Sources/Script/DependencyName.swift
+++ b/Sources/Script/DependencyName.swift
@@ -44,7 +44,8 @@ extension ImportSpecification.DependencyName: Codable {
                 let localRelativePathPrefix: Path
                 switch input {
                 case .path(let path):
-                    localRelativePathPrefix = path.containingDirectory ?? Path.cwd
+                    print("path found")
+                    localRelativePathPrefix = path.parent
                 case .string:
                     localRelativePathPrefix = Path.cwd
                 }

--- a/Sources/Script/ImportSpecification.swift
+++ b/Sources/Script/ImportSpecification.swift
@@ -86,17 +86,3 @@ private extension Version {
             """
     }
 }
-
-extension Path {
-    var containingDirectory: Path? {
-        guard self.isFile else {
-            return self
-        }
-
-        let filePath = self.string
-        if let lastSlash = filePath.lastIndex(of: "/") {
-            return Path(String(filePath[...lastSlash]))
-        }
-        return nil
-    }
-}

--- a/Sources/Script/ImportSpecification.swift
+++ b/Sources/Script/ImportSpecification.swift
@@ -23,10 +23,10 @@ public struct ImportSpecification: Codable, Equatable {
 }
 
 extension ImportSpecification {
-    public init?(line: String) throws {
+    public init?(line: String, from input: Script.Input) throws {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         guard trimmed.hasPrefix("import") || trimmed.hasPrefix("@testable") else { return nil }
-        guard let this = try parse(line) else { return nil }
+        guard let this = try parse(line, from: input) else { return nil }
         self = this
     }
 
@@ -84,5 +84,19 @@ private extension Version {
         return """
             "\(self)"
             """
+    }
+}
+
+extension Path {
+    var containingDirectory: Path? {
+        guard self.isFile else {
+            return self
+        }
+
+        let filePath = self.string
+        if let lastSlash = filePath.lastIndex(of: "/") {
+            return Path(String(filePath[...lastSlash]))
+        }
+        return nil
     }
 }

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -1,5 +1,4 @@
 import Foundation
-import Script
 import Utility
 import Version
 

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -1,4 +1,5 @@
 import Foundation
+import Script
 import Utility
 import Version
 
@@ -7,7 +8,7 @@ enum E: Error {
 }
 
 /// - Parameter line: Contract: Single line string trimmed of whitespace.
-func parse(_ line: String) throws -> ImportSpecification? {
+func parse(_ line: String, from input: Script.Input) throws -> ImportSpecification? {
     let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w\\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
 
@@ -44,7 +45,9 @@ func parse(_ line: String) throws -> ImportSpecification? {
 
     return ImportSpecification(
         importName: importName,
-        dependencyName: try .init(rawValue: String(line[match.range(at: 2)]), importName: importName),
+        dependencyName: try .init(rawValue: String(line[match.range(at: 2)]),
+                                  importName: importName,
+                                  from: input),
         constraint: constraint)
 }
 

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -70,7 +70,17 @@ class ImportSpecificationUnitTests: XCTestCase {
     }
 
     func testCanProvideLocalRelativeCurrentPath() throws {
+        let cwd = Path.cwd
+        let b = try parse("import Bar  // ./")
+        XCTAssertEqual(b?.dependencyName, .local(cwd))
+        XCTAssertEqual(b?.importName, "Bar")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(cwd.string)\")")
+    }
+
+    func testCanProvideLocalRelativeNonCurrentPath() throws {
         let homePath = Path.home
+        // CommandLine is populated with XCTest arguments during testing, add an input there.
+        CommandLine.arguments[1] = homePath.join("example_script.swift").string
         let b = try parse("import Bar  // ./")
         XCTAssertEqual(b?.dependencyName, .local(homePath))
         XCTAssertEqual(b?.importName, "Bar")

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -70,11 +70,11 @@ class ImportSpecificationUnitTests: XCTestCase {
     }
 
     func testCanProvideLocalRelativeCurrentPath() throws {
-        let cwd = Path.cwd
+        let homePath = Path.home
         let b = try parse("import Bar  // ./")
-        XCTAssertEqual(b?.dependencyName, .local(cwd))
+        XCTAssertEqual(b?.dependencyName, .local(homePath))
         XCTAssertEqual(b?.importName, "Bar")
-        XCTAssertEqual(b?.packageLine, ".package(path: \"\(cwd.string)\")")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\")")
     }
 
     func testCanProvideLocalRelativeParentPath() throws {

--- a/Tests/All/IntegrationTests.swift
+++ b/Tests/All/IntegrationTests.swift
@@ -105,6 +105,7 @@ class RunIntegrationTests: XCTestCase {
         let testDir = try Path.cwd.join("tempTestDir").mkdir()
         defer {_ = try? FileManager.default.removeItem(at: testDir.url)}
 
+        // Place the local_dep inside cwd/local_dep
         let task = Process(arg0: "/bin/bash")
         task.currentDirectoryPath = tmpDir.string
         task.arguments = ["-c", "swift package init"]
@@ -112,7 +113,13 @@ class RunIntegrationTests: XCTestCase {
         task.standardOutput = stdout
         try task.go()
         task.waitUntilExit()
-        
+
+        // Place the script inside cwd/tempTestDir
+        // Provide "../local_dep" as the relative path to local_dep.
+        //
+        // We specifically use a different directory than cwd
+        // to test that the script's provided relative path for local_dep
+        // is relative to the script's path and not relative to the current working directory.
         XCTAssertRuns(exec: """
            import local_dep  // ../\(depName)
         """, path: testDir)

--- a/Tests/All/IntegrationTests.swift
+++ b/Tests/All/IntegrationTests.swift
@@ -97,21 +97,25 @@ class RunIntegrationTests: XCTestCase {
     }
 
     func testUseLocalDependencyWithRelativePath() throws {
-        let depName = "local_dep"
-        let tmpdir = try Path.cwd.join(depName).mkdir()
-        defer {_ = try? FileManager.default.removeItem(at: tmpdir.url)}
+        let depName = "local_dep" 
+        let tmpDir = try Path.cwd.join(depName).mkdir()
+        defer {_ = try? FileManager.default.removeItem(at: tmpDir.url)}
+
+        // Use a dir under cwd because mkdir fails inside Path.mktemp
+        let testDir = try Path.cwd.join("tempTestDir").mkdir()
+        defer {_ = try? FileManager.default.removeItem(at: testDir.url)}
 
         let task = Process(arg0: "/bin/bash")
-        task.currentDirectoryPath = tmpdir.string
+        task.currentDirectoryPath = tmpDir.string
         task.arguments = ["-c", "swift package init"]
         let stdout = Pipe()
         task.standardOutput = stdout
         try task.go()
         task.waitUntilExit()
-
+        
         XCTAssertRuns(exec: """
-            import local_dep  // ./\(depName)
-            """)
+           import local_dep  // ../\(depName)
+        """, path: testDir)
     }
 
     func testStandardInputCanBeUsedInScript() throws {
@@ -512,18 +516,26 @@ class TestingTheTests: XCTestCase {
     }
 }
 
-private func write(script: String, line: UInt = #line, body: (Path) throws -> Void) throws {
-    try Path.mktemp { tmpdir -> Void in
-        let file = tmpdir.join("\(scriptBaseName)-\(line).swift")
+private func write(script: String, path: Path? = nil, line: UInt = #line, body: @escaping (Path) throws -> Void) throws {
+    let writeFile: (Path) throws -> Void = {
+        let file = $0.join("\(scriptBaseName)-\(line).swift")
         try "#!\(shebang)\n\(script)".write(to: file)
         try file.chmod(0o0500)
         try body(file)
+ 
     }
+    if let path = path {
+        try writeFile(path)
+    } else {
+        try Path.mktemp { tmpDir -> Void in
+            try writeFile(tmpDir)
+        }
+   }
 }
 
-private func XCTAssertRuns(exec: String, line: UInt = #line) {
+private func XCTAssertRuns(exec: String, path: Path? = nil, line: UInt = #line) {
     do {
-        try write(script: exec, line: line) { file in
+        try write(script: exec, path: path, line: line) { file in
             let task = Process(arg0: file)
             try task.go()
             task.waitUntilExit()

--- a/Tests/All/XCTestManifests.swift
+++ b/Tests/All/XCTestManifests.swift
@@ -38,6 +38,7 @@ extension ImportSpecificationUnitTests {
         ("testCanProvideLocalPath", testCanProvideLocalPath),
         ("testCanProvideLocalPathWithTilde", testCanProvideLocalPathWithTilde),
         ("testCanProvideLocalRelativeCurrentPath", testCanProvideLocalRelativeCurrentPath),
+        ("testCanProvideLocalRelativeNonCurrentPath", testCanProvideLocalRelativeNonCurrentPath),
         ("testCanProvideLocalRelativeParentPath", testCanProvideLocalRelativeParentPath),
         ("testCanProvideLocalRelativeTwoParentsUpPath", testCanProvideLocalRelativeTwoParentsUpPath),
         ("testCanUseTestable", testCanUseTestable),


### PR DESCRIPTION
### Problem:

Scripts inside a git repository which share local packages can only be run from one directory.
If I have a directory structure like this:

    git repo root
    | - Scripts/
        | - script.swift
        | - MyPackage/

And I import MyPackage in script.swift like this:
import MyPackage // ./MyPackage

I can only run the script from the Scripts directory. I can't specify an absolute path because it's a git repository that might be checked out to any location.

### Proposed Solution:

Paths should be specified as relative to the script's file location rather than being considered relative to the current working directory.

Combine location of script and location of package when resolving local paths with relative-to-script syntax to produce the path relative to the current working directory for the same execution as the existing relative paths.

    ./Scripts/script.swift + ./path/to/package == ./Scripts/path/to/package

### Notes on implementation:

This required taking the input path of the script and passing it through to `DependencyName.init` to be used in parsing the path to the dependency and turning it into a path relative to the given script's directory.

I modified the logic inside the `DependencyName.init` method to combine the provided relative path with the script's absolute path.  If the script is from a non-local source (`.string` case of `Script.Input`) then it defaults to looking relative to the cwd.  I don't feel strongly about this default value, so please let me know if you think it's inappropriate.  Perhaps we should throw instead?

### Notes on tests:
I modified the relative path integration test to utilize directories outside the cwd to properly test that the relative path is resolved relative to the script.

I also added a test under ImportSpecificationUnitTests to test the relative path when the script is outside of the cwd.  When using the `mktemp` method to get a temporary directory, I was unable to perform a `mkdir` on the provided temp directory, so I just went with making files as was done for specifying the directory of the `local_dep` package previously.

I needed to modify some of the test code to allow for writing the script to a non-temporary directory via `XTCAssertRuns` and added an optional `path` parameter to support this test.

Please let me know if you'd like additional tests added for cases I've missed.