### PR TITLE
Update README to point to homebrew's formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ wage*. Please help me continue my work, I appreciate it 🙏🏻
 # Installation
 
 ```
-brew install mxcl/made/swift-sh
+brew install swift-sh
 ```
 
 Or with [Mint](https://github.com/yonaskolb/Mint):


### PR DESCRIPTION
This PR updates the README to instruct people to execute `brew install swift-sh` as [the PR of swift-sh](http://github.com/homebrew/homebrew-core/pull/49956) has been merged.