### PR TITLE
Rebuild on local dependency changes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mxcl/Path.swift",
         "state": {
           "branch": null,
-          "revision": "dac007e907a4f4c565cfdc55a9ce148a761a11d5",
-          "version": "0.16.3"
+          "revision": "6e1eeb158ae0e71da3af23ef869aa0dc1adf7355",
+          "version": "1.0.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mxcl/StreamReader",
         "state": {
           "branch": null,
-          "revision": "ee3350052e7aa5c4fce73dced9c71e8d32c13303",
-          "version": "1.0.0"
+          "revision": "0cabaa9d539037da1b25b8cbe58a8ecafaedea67",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Command", targets: ["Command"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mxcl/Path.swift", from: "0.16.2"),
+        .package(url: "https://github.com/mxcl/Path.swift", from: "1.0.1"),
         .package(url: "https://github.com/mxcl/StreamReader", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/LegibleError", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),

--- a/Sources/Script/DependencyName.swift
+++ b/Sources/Script/DependencyName.swift
@@ -46,7 +46,7 @@ extension ImportSpecification.DependencyName: Codable {
                 case .path(let path):
                     localRelativePathPrefix = path.parent
                 case .string:
-                    localRelativePathPrefix = Path.cwd
+                    localRelativePathPrefix = Path(Path.cwd)
                 }
                 let localRelativePath = localRelativePathPrefix/cc.path
                 if localRelativePath.exists {

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -45,7 +45,7 @@ class ImportSpecificationUnitTests: XCTestCase {
         XCTAssertEqual(b?.constraint, .upToNextMajor(from: .one))
         XCTAssertEqual(b?.importName, "Foo")
     }
-    
+
     func testCanOverrideImportNameUsingNameWithHyphen() throws {
         let b = try parse("import Bar  // mxcl/swift-bar ~> 1.0", from: .path(Path.cwd.join("script.swift")))
         XCTAssertEqual(b?.dependencyName, .github(user: "mxcl", repo: "swift-bar"))
@@ -56,7 +56,7 @@ class ImportSpecificationUnitTests: XCTestCase {
     func testCanProvideLocalPath() throws {
         let homePath = Path.home
         let b = try parse("import Bar  // \(homePath.string)", from: .path(homePath.join("script.swift")))
-        XCTAssertEqual(b?.dependencyName, .local(homePath))
+        XCTAssertEqual(b?.dependencyName, .local(Path(homePath)))
         XCTAssertEqual(b?.importName, "Bar")
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\")")
     }
@@ -64,7 +64,7 @@ class ImportSpecificationUnitTests: XCTestCase {
     func testCanProvideLocalPathWithTilde() throws {
         let homePath = Path.home
         let b = try parse("import Bar  // ~/", from: .path(homePath.join("script.swift")))
-        XCTAssertEqual(b?.dependencyName, .local(homePath))
+        XCTAssertEqual(b?.dependencyName, .local(Path(homePath)))
         XCTAssertEqual(b?.importName, "Bar")
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\")")
     }
@@ -72,7 +72,7 @@ class ImportSpecificationUnitTests: XCTestCase {
     func testCanProvideLocalRelativeCurrentPath() throws {
         let cwd = Path.cwd
         let b = try parse("import Bar  // ./", from: .path(cwd.join("script.swift")))
-        XCTAssertEqual(b?.dependencyName, .local(cwd))
+        XCTAssertEqual(b?.dependencyName, .local(Path(cwd)))
         XCTAssertEqual(b?.importName, "Bar")
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(cwd.string)\")")
     }
@@ -81,7 +81,7 @@ class ImportSpecificationUnitTests: XCTestCase {
         let homePath = Path.home
         // Provide a script path that's inside the home directory (not cwd)
         let b = try parse("import Bar  // ./", from: .path(homePath.join("script.swift")))
-        XCTAssertEqual(b?.dependencyName, .local(homePath))
+        XCTAssertEqual(b?.dependencyName, .local(Path(homePath)))
         XCTAssertEqual(b?.importName, "Bar")
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(homePath.string)\")")
     }

--- a/Tests/All/IntegrationTests.swift
+++ b/Tests/All/IntegrationTests.swift
@@ -8,8 +8,8 @@ import Path
 class RunIntegrationTests: XCTestCase {
     override class func setUp() {
         guard Path.build.isDirectory else { return }
-        for entry in try! Path.build.ls() where entry.kind == .directory && entry.path.basename().hasPrefix(scriptBaseName) {
-            try! entry.path.delete()
+        for entry in Path.build.ls() where entry.type == .directory && DynamicPath(entry).path.basename().hasPrefix(scriptBaseName) {
+            try! DynamicPath(entry).path.delete()
         }
     }
 
@@ -97,7 +97,7 @@ class RunIntegrationTests: XCTestCase {
     }
 
     func testUseLocalDependencyWithRelativePath() throws {
-        let depName = "local_dep" 
+        let depName = "local_dep"
         let tmpDir = try Path.cwd.join(depName).mkdir()
         defer {_ = try? FileManager.default.removeItem(at: tmpDir.url)}
 
@@ -223,7 +223,7 @@ class RunIntegrationTests: XCTestCase {
     }
 
     func testNSHipsterExample() throws {
-        let path = Path(#file)!.parent.parent.parent.Examples.cards
+        let path = Path(DynamicPath(Path(#file)!.parent.parent.parent).Examples.cards)
         let code = try StreamReader(path: path).dropFirst().joined(separator: "\n")
         XCTAssertRuns(exec: code)
     }
@@ -529,7 +529,7 @@ private func write(script: String, path: Path? = nil, line: UInt = #line, body: 
         try "#!\(shebang)\n\(script)".write(to: file)
         try file.chmod(0o0500)
         try body(file)
- 
+
     }
     if let path = path {
         try writeFile(path)

--- a/Tests/All/ModeUnitTests.swift
+++ b/Tests/All/ModeUnitTests.swift
@@ -45,7 +45,7 @@ class ModeUnitTests: XCTestCase {
 
     func testValidRun() throws {
         try Path.mktemp { tmpdir in
-            let foo = try tmpdir.foo.touch()
+            let foo = try DynamicPath(tmpdir).foo.touch()
 
             func test(args: String..., line: UInt = #line) throws {
                 let mode = try Mode(for: ["arg0"] + args, isTTY: true)


### PR DESCRIPTION
Hey @mxcl, thanks for your work on swift-sh and hope you're doing okay during the coronavirus situation.

I've been working a lot with swift-sh scripts against local package dependencies. `// ./my/project` is awesome!

I noticed my script was often not rebuilding. swift-sh does consider the mtime of the script itself to decide to skip `swift build` on the internal `swift-sh.cache`. But it does not consider the local package dependency files themselves.

This PR includes a rough implementation of doing a recursive mtime check of any local package files.

I think this approach might be _okay_. It's kinda the `make` behavior. Without getting too clever, we don't know which flies are relevant to building the specific package target. So this just mtimes the entire nested directory. Maybe that could be scoped down to `Sources/*.swift` or something like that.

As this is another layer of caching on top of `swift build`, we could also just go the other direction and skip our check all together if local packages are involved. See https://github.com/mxcl/swift-sh/compare/master...josh:script-change-local-skip

A third variation could be to provide a manual build command. `--clean-cache` is very aggressive and blows away all cloned dependencies. But we could expose a `--force-build` flag or `swift-sh build` command that always rebuilds the internal package. https://github.com/mxcl/swift-sh/compare/master...josh:build-command

Will add tests and whatever else if you think this is a good idea.

Thanks!
@josh