### PR TITLE
Output Swift 5.2 style target dependencies

### DIFF
--- a/Sources/Script/DependencyName.swift
+++ b/Sources/Script/DependencyName.swift
@@ -87,7 +87,7 @@ extension ImportSpecification.DependencyName: Codable {
         var container = encoder.singleValueContainer()
         try container.encode(urlString)
     }
-
+    
     var urlString: String {
         switch self {
         case .github(let user, let repo):
@@ -98,6 +98,15 @@ extension ImportSpecification.DependencyName: Codable {
             return str
         case .local(let path):
             return path.string
+        }
+    }
+    
+    var packageName: String? {
+        let basename = urlString.split(separator: "/").last
+        if let name = basename?.split(separator: ".").first {
+            return String(name)
+        } else {
+            return nil
         }
     }
 }

--- a/Sources/Script/ImportSpecification.swift
+++ b/Sources/Script/ImportSpecification.swift
@@ -67,11 +67,17 @@ extension ImportSpecification {
 
 public extension Array where Element == ImportSpecification {
     var mainTargetDependencies: String {
-        return map {
-            """
-            .product(name: "\($0.importName)", package: "\($0.dependencyName.packageName ?? "")")
-            """
-            }.joined(separator: ", ")
+        #if swift(>=5.2)
+            return map { """
+                .product(name: "\($0.importName)", package: "\($0.dependencyName.packageName ?? "")")
+                """
+                }.joined(separator: ", ")
+        #else
+            return map { """
+                "\($0.importName)"
+                """
+                }.joined(separator: ", ")
+        #endif
     }
 
     var packageLines: String {

--- a/Sources/Script/ImportSpecification.swift
+++ b/Sources/Script/ImportSpecification.swift
@@ -67,8 +67,9 @@ extension ImportSpecification {
 
 public extension Array where Element == ImportSpecification {
     var mainTargetDependencies: String {
-        return map { """
-            "\($0.importName)"
+        return map {
+            """
+            .product(name: "\($0.importName)", package: "\($0.dependencyName.packageName ?? "")")
             """
             }.joined(separator: ", ")
     }

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -246,7 +246,9 @@ let swiftVersion: String = {
     } catch {
         assert(false)  // shouldn't happen during testing so let’s catch it
     }
-#if swift(>=5.1)
+#if swift(>=5.2)
+    return "5.2"
+#elseif swift(>=5.1)
     return "5.1"
 #elseif swift(>=5)
     return "5.0"


### PR DESCRIPTION
Instead of outputting 
```
.target(name: "my-target", dependencies: ["MyDep"])
```
this will now output
```
.target(name: "my-target", dependencies: [.product(name: "MyDep", package: "my-dep")])
```

This will mean dependencies with a different target name from their repository name will work. An example repository this will fix is https://github.com/apple/swift-argument-parser. 