### PR TITLE
Fixes for the Edit Command

### DIFF
--- a/Sources/swift-sh-edit/main.swift
+++ b/Sources/swift-sh-edit/main.swift
@@ -19,6 +19,7 @@ let debug = XCBuildConfiguration(name: "Debug", buildSettings: [
     "FRAMEWORK_SEARCH_PATHS": ".build/debug",
     "HEADER_SEARCH_PATHS": ".build/debug",
     "LIBRARY_SEARCH_PATHS": ".build/debug",
+    "SWIFT_INCLUDE_PATHS": ".build/debug",
     "SWIFT_VERSION": "4.2",  //FIXME
 ])
 let confs = XCConfigurationList(buildConfigurations: [debug], defaultConfigurationName: "Debug")

--- a/Sources/swift-sh-edit/main.swift
+++ b/Sources/swift-sh-edit/main.swift
@@ -32,7 +32,11 @@ let rootObject = PBXProject(
     mainGroup: mainGroup
 )
 
-let pbxProj = PBXProj(rootObject: rootObject)
+// The object version seems to indicate the model version used to encode the PBXProj file. Setting this value too
+// high could yield a project file that is not editable in any production version of Xcode (i.e. Xcode 12 = 54).
+let objectVersion: UInt = 51
+
+let pbxProj = PBXProj(rootObject: rootObject, objectVersion: objectVersion)
 
 let proj = XcodeProj(workspace: XCWorkspace(), pbxproj: pbxProj)
 

--- a/Sources/swift-sh-edit/main.swift
+++ b/Sources/swift-sh-edit/main.swift
@@ -33,7 +33,7 @@ let rootObject = PBXProject(
 )
 
 // The object version seems to indicate the model version used to encode the PBXProj file. Setting this value too
-// high could yield a project file that is not editable in any production version of Xcode (i.e. Xcode 12 = 54).
+// high could yield a project file that is not editable in any production version of Xcode (i.e. Xcode 12 == 54).
 let objectVersion: UInt = 51
 
 let pbxProj = PBXProj(rootObject: rootObject, objectVersion: objectVersion)


### PR DESCRIPTION
This addresses issues #87 and #126.

Setting the explicit object version seems kind of gross but does protect against a dependency setting a version that is still pre-release.