### PR TITLE
Fix macOS version mappings for Big Sur compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         swift:
         - 5.1
         - 5.2
-        # - 5.3  # doesn’t work yet annoyingly
+        - 5.3  # doesn’t work yet annoyingly
     steps:
     - uses: actions/checkout@v2
     - uses: fwal/setup-swift@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: setup-xcode
-      uses: maxim-lobanov/setup-xcode@1.0
+      uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ matrix.xcode }}
     - run: swift test -Xswiftc -suppress-warnings

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -75,10 +75,15 @@ public class Script {
 
             var macOS: String {
                 let version = ProcessInfo.processInfo.operatingSystemVersion
-                if version.majorVersion == 11 && version.minorVersion == 0 {
+                switch (version.majorVersion, version.minorVersion) {
+                case (10, 16):
+                    // v10_16 has been deprecated in favour of v11
+                    // see: https://developer.apple.com/documentation/swift_packages/supportedplatform/macosversion/3632902-v11
+                    return "v11"
+                case (11, 0):
                     // swift-tools-version 5.1 doesn’t have the v11 value
                     return "v10_15"
-                } else {
+                default:
                     return "v\(version.majorVersion)_\(version.minorVersion)"
                 }
             }


### PR DESCRIPTION
The Swift package generated by `swift-sh` currently maps the `ProcessInfo` reported `majorVersion` and `minorVersion` to the format: `v{majorVersion}_{minorVersion}` to form the case name used as the `SupportedPlatform.MacOSVersion`.

On macOS Big Sur `ProcessInfo` reports the major version as `10` and minor version as `16`, forming the `v10_16` case name. However, `v10_16` has been deprecated in favour of `v11` (see [here](https://developer.apple.com/documentation/swift_packages/supportedplatform/macosversion)).

This code modifies the mapping produced in `Script.swift` to correctly map to the new `v11` case.