### PR TITLE
Fix for Big Sur (both 11.0 and 11.1, and future 11.x versions), while also still working on 10.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         swift:
         - 5.1
         - 5.2
-        # - 5.3  # doesn’t work yet annoyingly
+        - 5.3
     steps:
     - uses: actions/checkout@v2
     - uses: fwal/setup-swift@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: setup-xcode
-      uses: maxim-lobanov/setup-xcode@1.0
+      uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ matrix.xcode }}
     - run: swift test -Xswiftc -suppress-warnings

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -75,11 +75,11 @@ public class Script {
 
             var macOS: String {
                 let version = ProcessInfo.processInfo.operatingSystemVersion
-                if version.majorVersion == 11 && version.minorVersion == 0 {
-                    // swift-tools-version 5.1 doesn’t have the v11 value
-                    return "v10_15"
+				if version.majorVersion == 11 {
+                    // swift-tools-version 5.1 doesn’t have the v11 or v11_1 etc values
+					return ".macOS(\"\(version.majorVersion).\(version.minorVersion)\")"
                 } else {
-                    return "v\(version.majorVersion)_\(version.minorVersion)"
+                    return ".macOS(.v\(version.majorVersion)_\(version.minorVersion))"
                 }
             }
 
@@ -108,7 +108,7 @@ public class Script {
 
                 #if swift(>=5) && os(macOS)
                 pkg.platforms = [
-                   .macOS(.\(macOS))
+                   \(macOS)
                 ]
                 #endif
 

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -75,8 +75,8 @@ public class Script {
 
             var macOS: String {
                 let version = ProcessInfo.processInfo.operatingSystemVersion
-                if version.majorVersion == 11 { // && version.minorVersion == 0 {
-                    // swift-tools-version 5.1 doesn’t have the v11 value
+                if version.majorVersion == 11 {
+                    // swift-tools-version 5.1 doesn’t have the v11 or v11_1 values
                     return ".macOS(\"\(version.majorVersion).\(version.minorVersion)\")"
                 } else {
                     return ".macOS(.v\(version.majorVersion)_\(version.minorVersion))"

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -76,7 +76,7 @@ public class Script {
             var macOS: String {
                 let version = ProcessInfo.processInfo.operatingSystemVersion
                 if version.majorVersion == 11 {
-                    // swift-tools-version 5.1 doesn’t have the v11 or v11_1 values
+                    // swift-tools-version 5.1 doesn’t have the v11 or v11_1 values 
                     return ".macOS(\"\(version.majorVersion).\(version.minorVersion)\")"
                 } else {
                     return ".macOS(.v\(version.majorVersion)_\(version.minorVersion))"

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -75,9 +75,9 @@ public class Script {
 
             var macOS: String {
                 let version = ProcessInfo.processInfo.operatingSystemVersion
-				if version.majorVersion == 11 {
-                    // swift-tools-version 5.1 doesn’t have the v11 or v11_1 etc values
-					return ".macOS(\"\(version.majorVersion).\(version.minorVersion)\")"
+                if version.majorVersion == 11 { // && version.minorVersion == 0 {
+                    // swift-tools-version 5.1 doesn’t have the v11 value
+                    return ".macOS(\"\(version.majorVersion).\(version.minorVersion)\")"
                 } else {
                     return ".macOS(.v\(version.majorVersion)_\(version.minorVersion))"
                 }
@@ -108,7 +108,7 @@ public class Script {
 
                 #if swift(>=5) && os(macOS)
                 pkg.platforms = [
-                   \(macOS)
+                    \(macOS)
                 ]
                 #endif
 


### PR DESCRIPTION
Should work on macOS 11.x instead of just 11.0 like some other PRs.
Works on macOS 10.15.7 unlike another PR.

Tested locally specifically on macOS v10.15.7 (Xcode 12.2) on an x86 MBP, and macOS v11.1.0 (Xcode 12.3) on an M1 MBP.
