### PR TITLE
Fix CI by using up2date version of `setup-xcode`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: setup-xcode
-      uses: maxim-lobanov/setup-xcode@1.0
+      uses: maxim-lobanov/setup-xcode@v1.2.1
       with:
         xcode-version: ${{ matrix.xcode }}
     - run: swift test -Xswiftc -suppress-warnings


### PR DESCRIPTION
macOS CI seems to fail. In my projects I managed to fix that by using a current version instead of 1.0.