### PR TITLE
fixes #132 - support spaces in local module paths

### DIFF
--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -8,7 +8,7 @@ enum E: Error {
 
 /// - Parameter line: Contract: Single line string trimmed of whitespace.
 func parse(_ line: String, from input: Script.Input) throws -> ImportSpecification? {
-    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w\\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
+    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w \\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
 
     // doesn’t look like an import line, we have to silently ignore it, even though it could
@@ -44,7 +44,7 @@ func parse(_ line: String, from input: Script.Input) throws -> ImportSpecificati
 
     return ImportSpecification(
         importName: importName,
-        dependencyName: try .init(rawValue: String(line[match.range(at: 2)]),
+        dependencyName: try .init(rawValue: String(line[match.range(at: 2)].trimmingCharacters(in: .whitespaces)),
                                   importName: importName,
                                   from: input),
         constraint: constraint)


### PR DESCRIPTION
This works, and all tests pass, including the new ones added to test the new functionality, but I’m not that happy with it.  

Seems like there should be a smarter regular expression change that can reduce the two extra trimming of spaces off the end of things which I had to add.

Does work, but…  

Making a PR so CI can chew on it.

This does, at least, illustrate the two challenges adding support for spaces as per #132 involves:
- update the Regular Expression in `parse().swift`
- deal with the fact that URLComponents can't handle an unescaped space in a path.
