### PR TITLE
An alternate version of PR #139 that fixes #132

### DIFF
--- a/Sources/Script/DependencyName.swift
+++ b/Sources/Script/DependencyName.swift
@@ -24,7 +24,7 @@ extension ImportSpecification.DependencyName: Codable {
             //FIXME strictly not a thorough github username check
             //NOTE the `.` is not actually allowed, but GitHub allows using it when creating usernames/orgs but converts it to `-` so we must do the same
             let validCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-.")
-            let username = String(string.dropFirst()).trimmingCharacters(in: .whitespaces)
+            let username = String(string.dropFirst())
             guard CharacterSet(charactersIn: username).isSubset(of: validCharacters) else {
                 throw E.invalidGitHubUsername(username)
             }

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -15,7 +15,7 @@ func parse(_ line: String, from input: Script.Input) throws -> ImportSpecificati
     let repoConstraintPattern = "(?:(==|~>)\\s*([^\\s]+))?"
     let pattern = "\(importModNamePattern)\\s*\(commentPattern)\\s*(\(localFilePattern)|\(repoRefPattern))\\s*\(repoConstraintPattern)"
     // or if you prefer, one big pattern:
-    //      let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*((?:(?:~|[\\./]+)+?[\\w \\/]*)|(?:(?:[(@|\\w)]?[\\w\\/(@|:)\\.\\-]+)))\\s*(?:(==|~>)\\s*([^\\s]+))?"
+    //      let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*((?:(?:~|[\\./]+)+?[\\w \\/\\.\\-]*)|(?:(?:[(@|\\w)]?[\\w\\/(@|:)\\.\\-]+)))\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
 
     // match 0: whole string

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -8,9 +8,25 @@ enum E: Error {
 
 /// - Parameter line: Contract: Single line string trimmed of whitespace.
 func parse(_ line: String, from input: Script.Input) throws -> ImportSpecification? {
-    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w \\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
+    let importModNamePattern = "import\\s+(.*?)"
+    let commentPattern = "\\/\\/"
+    let localFilePattern = "(?:(?:~|[\\./]+)+?[\\w \\/]*)"
+    let repoRefPattern = "(?:(?:[(@|\\w)]?[\\w\\/(@|:)\\.\\-]+))"
+    let repoConstraintPattern = "(?:(==|~>)\\s*([^\\s]+))?"
+    let pattern = "\(importModNamePattern)\\s*\(commentPattern)\\s*(\(localFilePattern)|\(repoRefPattern))\\s*\(repoConstraintPattern)"
+    // or if you prefer, one big pattern:
+    //      let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*((?:(?:~|[\\./]+)+?[\\w \\/]*)|(?:(?:[(@|\\w)]?[\\w\\/(@|:)\\.\\-]+)))\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
 
+    // match 0: whole string
+    // match 1: module name
+    // match 2: one of:
+    //          user ref (e.g., @mxcl)
+    //          local file ref (e.g., ./my/project or ../my/project or ~/foo, or /foo/bar)
+    //          url ref (e.g., https://foo/bar.git or git@github.com:user/repo.git or ssh://git@github.com:user/repo.git)
+    // match 3: range spec (e.g., ~> or ==) -- IFF NOT local file ref (and match 8 valid))
+    // match 4: range value (e.g., 1.0.0-alpha.1 or b27a89 or 1) -- IFF NOT local file ref (and match 7 valid)
+    
     // doesn’t look like an import line, we have to silently ignore it, even though it could
     // be a typo or whatever which is not useful to our user, but at the end of the day
     // we’re a hack waiting for a real API in Swift itself that can then error properly
@@ -44,7 +60,7 @@ func parse(_ line: String, from input: Script.Input) throws -> ImportSpecificati
 
     return ImportSpecification(
         importName: importName,
-        dependencyName: try .init(rawValue: String(line[match.range(at: 2)].trimmingCharacters(in: .whitespaces)),
+        dependencyName: try .init(rawValue: String(line[match.range(at: 2)]),
                                   importName: importName,
                                   from: input),
         constraint: constraint)

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -8,7 +8,7 @@ enum E: Error {
 
 /// - Parameter line: Contract: Single line string trimmed of whitespace.
 func parse(_ line: String, from input: Script.Input) throws -> ImportSpecification? {
-    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w\\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
+    let pattern = "import\\s+(.*?)\\s*\\/\\/\\s*([~@]?[\\w \\/(@|:)\\.\\-]+)\\s*(?:(==|~>)\\s*([^\\s]+))?"
     let rx = try! NSRegularExpression(pattern: pattern)
 
     // doesn’t look like an import line, we have to silently ignore it, even though it could
@@ -44,7 +44,7 @@ func parse(_ line: String, from input: Script.Input) throws -> ImportSpecificati
 
     return ImportSpecification(
         importName: importName,
-        dependencyName: try .init(rawValue: String(line[match.range(at: 2)]),
+        dependencyName: try .init(rawValue: String(line[match.range(at: 2)].trimmingCharacters(in: .whitespaces)),
                                   importName: importName,
                                   from: input),
         constraint: constraint)

--- a/Sources/Script/parse().swift
+++ b/Sources/Script/parse().swift
@@ -10,7 +10,7 @@ enum E: Error {
 func parse(_ line: String, from input: Script.Input) throws -> ImportSpecification? {
     let importModNamePattern = "import\\s+(.*?)"
     let commentPattern = "\\/\\/"
-    let localFilePattern = "(?:(?:~|[\\./]+)+?[\\w \\/]*)"
+    let localFilePattern = "(?:(?:~|[\\./]+)+?[\\w \\/\\.\\-]*)"
     let repoRefPattern = "(?:(?:[(@|\\w)]?[\\w\\/(@|:)\\.\\-]+))"
     let repoConstraintPattern = "(?:(==|~>)\\s*([^\\s]+))?"
     let pattern = "\(importModNamePattern)\\s*\(commentPattern)\\s*(\(localFilePattern)|\(repoRefPattern))\\s*\(repoConstraintPattern)"

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -102,6 +102,24 @@ class ImportSpecificationUnitTests: XCTestCase {
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(cwdParent.string)\")")
     }
 
+    func testCanProvideLocalPathWithHypen() throws {
+        let tmpPath = Path.root.tmp.fake/"with-hyphen-two"/"lastone"
+        try tmpPath.mkdir(.p)
+        let b = try parse("import Foo  // /tmp/fake/with-hyphen-two/lastone", from: .path(tmpPath.join("script.swift")))
+        XCTAssertEqual(b?.dependencyName, .local(tmpPath))
+        XCTAssertEqual(b?.importName, "Foo")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(tmpPath.string)\")")
+    }
+
+    func testCanProvideLocalPathWithHyphenAndDotsAndSpacesOhMy() throws {
+        let tmpPath = Path.root.tmp.fake/"with-hyphen.two.one-zero"/"last one"
+        try tmpPath.mkdir(.p)
+        let b = try parse("import Foo  // /tmp/fake/with-hyphen.two.one-zero/last one", from: .path(tmpPath.join("script.swift")))
+        XCTAssertEqual(b?.dependencyName, .local(tmpPath))
+        XCTAssertEqual(b?.importName, "Foo")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(tmpPath.string)\")")
+    }
+
     func testCanProvideLocalPathWithSpaces() throws {
         let tmpPath = Path.root.tmp.fake/"with space"/"last"
         try tmpPath.mkdir(.p)
@@ -137,7 +155,6 @@ class ImportSpecificationUnitTests: XCTestCase {
         XCTAssertEqual(b?.importName, "Bar")
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(tmpPath.string)\")")
     }
-
 
     func testCanProvideFullURL() throws {
         let b = try parse("import Foo  // https://example.com/mxcl/Bar.git ~> 1.0", from: .path(Path.cwd.join("script.swift")))

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -120,6 +120,25 @@ class ImportSpecificationUnitTests: XCTestCase {
         XCTAssertEqual(b?.packageLine, ".package(path: \"\(tmpPath.string)\")")
     }
 
+    func testCanProvideLocalPathWithSpacesAndRelativeParentsUp() throws {
+        let tmpPath = Path.root.tmp.fake.fakechild/".."/"with space"/"last"
+        try tmpPath.mkdir(.p)
+        let b = try parse("import Bar  // /tmp/fake/with space/last", from: .path(tmpPath.join("script.swift")))
+        XCTAssertEqual(b?.dependencyName, .local(tmpPath))
+        XCTAssertEqual(b?.importName, "Bar")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(tmpPath.string)\")")
+    }
+    
+    func testCanProvideLocalPathWithSpacesAndRelativeParentsUpTwo() throws {
+        let tmpPath = Path.root.tmp.fake.fakechild1.fakechild2/"../.."/"with space"/"last"
+        try tmpPath.mkdir(.p)
+        let b = try parse("import Bar  // /tmp/fake/with space/last", from: .path(tmpPath.join("script.swift")))
+        XCTAssertEqual(b?.dependencyName, .local(tmpPath))
+        XCTAssertEqual(b?.importName, "Bar")
+        XCTAssertEqual(b?.packageLine, ".package(path: \"\(tmpPath.string)\")")
+    }
+
+
     func testCanProvideFullURL() throws {
         let b = try parse("import Foo  // https://example.com/mxcl/Bar.git ~> 1.0", from: .path(Path.cwd.join("script.swift")))
         XCTAssertEqual(b?.dependencyName, .url(URL(string: "https://example.com/mxcl/Bar.git")!))


### PR DESCRIPTION
Alternate version of #139 that uses an expanded regular expression to fix #132 - handle spaces in file specifiers - without letting the user or repo specifiers get extra spaces added to them.

I broke regular expression up into easier to grok pieces because it’s getting long.
I left the single expression version in comment.
If you let me know which version of the expression (single or compound) you like best and I'll update this to use that one and clean out the other.