### PR TITLE
Fix issue with macOS Big Sur by using latest tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /sync
 /.swiftpm
 /.build
+.DS_Store

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -76,8 +76,7 @@ public class Script {
             var macOS: String {
                 let version = ProcessInfo.processInfo.operatingSystemVersion
                 if version.majorVersion == 11 {
-                    // swift-tools-version 5.1 doesn’t have the v11 or v11_1 values 
-                    return ".macOS(\"\(version.majorVersion).\(version.minorVersion)\")"
+                    return ".macOS(.v11)"
                 } else {
                     return ".macOS(.v\(version.majorVersion)_\(version.minorVersion))"
                 }
@@ -85,7 +84,7 @@ public class Script {
 
             try buildDirectory.mkdir(.p)
             try """
-                // swift-tools-version:5.1
+                // swift-tools-version:5.3
                 import PackageDescription
 
                 let pkg = Package(name: "\(name)")


### PR DESCRIPTION
Fixes #142.

Install my fix before it's merged by running:
```bash
brew uninstall --ignore-dependencies swift-sh
brew install mint
mint install Jeehut/swift-sh@master
swift-sh --clean-cache
```

Once a proper fix is released, go back to original swift-sh by running:
```bash
mint uninstall Jeehut/swift-sh
brew install swift-sh
swift-sh --clean-cache
```