### PR TITLE
Fix #146 Linux workflow build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         swift-version: ${{ matrix.swift }}
     - run: swift test -Xswiftc -suppress-warnings --enable-test-discovery
-  linux5.1:
+  linux5_1:
     needs: auto-cancel
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,21 @@ jobs:
     strategy:
       matrix:
         swift:
-        - 5.1
         - 5.2
         - 5.3
+    steps:
+    - uses: actions/checkout@v2
+    - uses: fwal/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
+    - run: swift test -Xswiftc -suppress-warnings --enable-test-discovery
+  linux5.1:
+    needs: auto-cancel
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        swift:
+        - 5.1
     steps:
     - uses: actions/checkout@v2
     - uses: fwal/setup-swift@v1


### PR DESCRIPTION
Fixes #146 

Github apparently updated `ubuntu-latest` to Ubuntu 20.04 and Swift 5.1 isn't available on that OS.  So split the Swift 5.1 workflow build to it's own matrix (non-optimally but easier to maintain if identical to main linux build step) and set it to use previous ubuntu runner (ubuntu 18).