### PR TITLE
Use newer CryptoSwift to resolve exported:true build error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/mxcl/StreamReader", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/LegibleError", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "0.15.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.4.0"),
     ],
     targets: [
         .target(name: "swift-sh", dependencies: ["Command", "LegibleError"], path: "Sources", sources: ["main.swift"]),


### PR DESCRIPTION
Not sure CryptoSwift 1.4.0 supports old enough compilers also.  Let CI decide