### PR TITLE
Swift/5.4 - remove CryptoSwift dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,11 @@ let package = Package(
         .package(url: "https://github.com/mxcl/StreamReader", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/LegibleError", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.4.0"),
     ],
     targets: [
         .target(name: "swift-sh", dependencies: ["Command", "LegibleError"], path: "Sources", sources: ["main.swift"]),
         .target(name: "Script", dependencies: ["Utility", "StreamReader"]),
-        .target(name: "Utility", dependencies: ["Path", "Version", "CryptoSwift"]),
+        .target(name: "Utility", dependencies: ["Path", "Version"]),
         .target(name: "Command", dependencies: ["Script"]),
         .testTarget(name: "All", dependencies: ["swift-sh"]),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/mxcl/StreamReader", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/LegibleError", from: "1.0.0"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "0.15.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.4.0"),
     ],
     targets: [
         .target(name: "swift-sh", dependencies: ["Command", "LegibleError"], path: "Sources", sources: ["main.swift"]),

--- a/Sources/Utility/Path+ResolvedHash.swift
+++ b/Sources/Utility/Path+ResolvedHash.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Path
-import CryptoSwift
+
+import var CommonCrypto.CC_MD5_DIGEST_LENGTH
+import func CommonCrypto.CC_MD5
+import typealias CommonCrypto.CC_LONG
+
 
 extension Path {
     public var resolvedHash: String {
@@ -10,6 +14,29 @@ extension Path {
         } catch {
             destination = string
         }
-        return destination.md5()
+        return destination.MD5()
     }
+}
+
+
+extension String {
+    // from https://stackoverflow.com/a/32166735/145108
+    // modified to be an instance method that returns a string
+    func MD5() -> String {
+            let length = Int(CC_MD5_DIGEST_LENGTH)
+            let messageData = self.data(using:.utf8)!
+            var digestData = Data(count: length)
+
+            _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in
+                messageData.withUnsafeBytes { messageBytes -> UInt8 in
+                    if let messageBytesBaseAddress = messageBytes.baseAddress, let digestBytesBlindMemory = digestBytes.bindMemory(to: UInt8.self).baseAddress {
+                        let messageLength = CC_LONG(messageData.count)
+                        CC_MD5(messageBytesBaseAddress, messageLength, digestBytesBlindMemory)
+                    }
+                    return 0
+                }
+            }
+            let digestString = digestData.map { String(format: "%02hhx", $0) }.joined()
+            return digestString
+        }
 }

--- a/Sources/Utility/Path+ResolvedHash.swift
+++ b/Sources/Utility/Path+ResolvedHash.swift
@@ -24,7 +24,7 @@ extension String {
     // modified to be an instance method that returns a string
     func MD5() -> String {
             let length = Int(CC_MD5_DIGEST_LENGTH)
-            let messageData = self.data(using:.utf8)!
+            guard let messageData = self.data(using:.utf8)  else { return self }
             var digestData = Data(count: length)
 
             _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in

--- a/Tests/All/ImportSpecificationUnitTests.swift
+++ b/Tests/All/ImportSpecificationUnitTests.swift
@@ -169,7 +169,9 @@ class ImportSpecificationUnitTests: XCTestCase {
 
     func testSwiftVersion() {
     #if swift(>=5) || compiler(>=5.0)
-    #if compiler(>=5.3)
+    #if compiler(>=5.4)
+        let expected = "5.4"
+    #elseif compiler(>=5.3)
         let expected = "5.3"
     #elseif compiler(>=5.2)
         let expected = "5.2"

--- a/Tests/All/IntegrationTests.swift
+++ b/Tests/All/IntegrationTests.swift
@@ -510,7 +510,9 @@ class TestingTheTests: XCTestCase {
     func testSwiftVersionIsWhatTestsExpect() {
         let expected = swiftVersion
         XCTAssertEqual(expected, exec: """
-            #if swift(>=5.3)
+            #if swift(>=5.4)
+                print(5.4)
+            #elseif swift(>=5.3)
                 print(5.3)
             #elseif swift(>=5.2)
                 print(5.2)


### PR DESCRIPTION
CryptoSwift that works with Swift 5.4 doesn't support back to 10.10.
Not sure if new way works on linux though…. Let CI checks look into this