### PR TITLE
Added support for @main attribute based scripts

### DIFF
--- a/Examples/async-main-count-lines
+++ b/Examples/async-main-count-lines
@@ -1,0 +1,16 @@
+#!/user/bin/swift sh
+import Foundation
+import ArgumentParser // apple/swift-argument-parser ~> 1.4.0
+
+/// example borrowed from [here](https://swiftpackageindex.com/apple/swift-argument-parser/1.4.0/documentation/argumentparser/asyncparsablecommand)
+@main
+struct CountLines: AsyncParsableCommand {
+    @Argument(transform: URL.init(fileURLWithPath:))
+    var inputFile: URL
+    mutating func run() async throws {
+        let fileHandle = try FileHandle(forReadingFrom: inputFile)
+        let lineCount = try await fileHandle.bytes.lines.reduce(into: 0)
+            { count, _ in count += 1 }
+        print(lineCount)
+    }
+}

--- a/Sources/Command/edit().swift
+++ b/Sources/Command/edit().swift
@@ -7,8 +7,15 @@ import Path
 public func edit(path: Path) throws -> Never {
 #if os(macOS)
     let input:Script.Input = .path(path)
-    let deps = try StreamReader(path: path).compactMap { try ImportSpecification(line: $0, from: input) }
-    let script = Script(for: .path(path), dependencies: deps)
+    let reader = try StreamReader(path: path)
+    var style: ExecutableTargetMainStyle = .topLevelCode
+    let deps = try reader.compactMap { line in
+        if line.contains("@main") && !(line.contains("//") || line.contains("/*")) {
+            style = .mainAttribute
+        }
+        return try ImportSpecification(line: line, from: input)
+    }
+    let script = Script(for: .path(path), style: style, dependencies: deps)
     try script.write()
     try exec(arg0: "/usr/bin/swift", args: ["sh-edit", path.string, script.buildDirectory.string])
 #else

--- a/Sources/Command/edit().swift
+++ b/Sources/Command/edit().swift
@@ -9,7 +9,7 @@ public func edit(path: Path) throws -> Never {
     let input:Script.Input = .path(path)
     let reader = try StreamReader(path: path)
     var style: ExecutableTargetMainStyle = .topLevelCode
-    let deps = try reader.compactMap { line in
+    let deps: [ImportSpecification] = try reader.compactMap { line in
         if line.contains("@main") && !(line.contains("//") || line.contains("/*")) {
             style = .mainAttribute
         }

--- a/Sources/Command/editor().swift
+++ b/Sources/Command/editor().swift
@@ -8,7 +8,7 @@ public func editor(path: Path) throws -> Never {
     let input:Script.Input = .path(path)
     let reader = try StreamReader(path: path)
     var style: ExecutableTargetMainStyle = .topLevelCode
-    let deps = try reader.compactMap { line in
+    let deps: [ImportSpecification] = try reader.compactMap { line in
         if line.contains("@main") && !(line.contains("//") || line.contains("/*")) {
             style = .mainAttribute
         }

--- a/Sources/Command/editor().swift
+++ b/Sources/Command/editor().swift
@@ -6,8 +6,15 @@ import Path
 
 public func editor(path: Path) throws -> Never {
     let input:Script.Input = .path(path)
-    let deps = try StreamReader(path: path).compactMap { try ImportSpecification(line: $0, from: input) }
-    let script = Script(for: .path(path), dependencies: deps)
+    let reader = try StreamReader(path: path)
+    var style: ExecutableTargetMainStyle = .topLevelCode
+    let deps = try reader.compactMap { line in
+        if line.contains("@main") && !(line.contains("//") || line.contains("/*")) {
+            style = .mainAttribute
+        }
+        return try ImportSpecification(line: line, from: input)
+    }
+    let script = Script(for: .path(path), style: style, dependencies: deps)
     try script.write()
 
     guard let editor = ProcessInfo.processInfo.environment["EDITOR"] else {

--- a/Sources/Script/ExecutableTargetMainStyle.swift
+++ b/Sources/Script/ExecutableTargetMainStyle.swift
@@ -1,0 +1,8 @@
+
+/// wheter the script has @main
+public enum ExecutableTargetMainStyle {
+    /// script has @main, script source file cannot be named main.swift, as this would be compilation error
+    case mainAttribute
+    /// script doesn't have @main, and it's ok to have main.swift file as script source
+    case topLevelCode
+}

--- a/Sources/Script/Script.swift
+++ b/Sources/Script/Script.swift
@@ -44,7 +44,6 @@ public class Script {
         case string(name: String, content: String)
     }
 
-    #warning("need to walk over other places which initialize script and add checks for executable style")
     public init(for: Input, style: ExecutableTargetMainStyle, dependencies: [ImportSpecification], arguments: [String] = []) {
         input = `for`
         deps = dependencies


### PR DESCRIPTION
Fixes #163. 
Added `Examples/async-main-count-lines` which is just [this example](https://swiftpackageindex.com/apple/swift-argument-parser/1.4.0/documentation/argumentparser/asyncparsablecommand) from [swift-argument-parser](https://github.com/apple/swift-argument-parser) with `#!/user/bin/swift sh` at the top:
```swift
#!/user/bin/swift sh
import Foundation
import ArgumentParser // apple/swift-argument-parser ~> 1.4.0

/// example borrowed from [here](https://swiftpackageindex.com/apple/swift-argument-parser/1.4.0/documentation/argumentparser/asyncparsablecommand)
@main
struct CountLines: AsyncParsableCommand {
    @Argument(transform: URL.init(fileURLWithPath:))
    var inputFile: URL
    mutating func run() async throws {
        let fileHandle = try FileHandle(forReadingFrom: inputFile)
        let lineCount = try await fileHandle.bytes.lines.reduce(into: 0)
            { count, _ in count += 1 }
        print(lineCount)
    }
}
```
Added `let mainStyle: ExecutableTargetMainStyle` property to `Script`:
```swift
/// wheter the script has @main
public enum ExecutableTargetMainStyle {
    /// script has @main, script source file cannot be named main.swift, as this would be compilation error
    case mainAttribute
    /// script doesn't have @main, and it's ok to have main.swift file as script source
    case topLevelCode
}
```
To achieve successful compilation with `@main` attribute needed to change `swift-tools-version` to `5.5`, and swap `.target` for `.executableTarget`.
Also as comment mentions we can not have `main.swift` as `source` when we have `@main`, so the resulting script source filename is changed to `Root.swift`.
Also we cannot have `#!` not in `main.swift` so it's filtered out when `Script`'s `mainStyle` is `.mainAttribute`.

Tested this by running `swift-sh` target in Xcode 15.4 and passing two input arguments which are both absolute path to added example.
Didn't test `stdin` based input.

All of the aforementioned changes only happen when we found a line containing `@main` and decided that `Script` `mainStyle` is `.mainAttribute`.

@helje5 suggested to have following change to shebang line `#!/usr/bin/swift sh #@main`, but i found it unnecessary, and currently check if script uses `@main` like this: 
```swift
/// line has `@main`, line is not a comment.
line.contains("@main") && !(line.contains("//") || line.contains("/*"))
```

Unfortunately linking file as was previously isn't an option when a file has `@main` as only `main.swift` is allowed to have shebang `#!` and we need to remove that line in order for script having `@main` to compile successfully. So `@main` attribute and `main.swift` are mutually exclusive.
